### PR TITLE
Port python2 scripts to python3

### DIFF
--- a/check.py
+++ b/check.py
@@ -23,7 +23,7 @@ class TestLoader(unittest.TestCase):
         self.assertLessEqual(len(loader._by_uuid), len(loader._confs))
         self.assertGreaterEqual(len(loader._by_uuid), 3)
 
-        for i in loader._by_uuid.itervalues():
+        for i in loader._by_uuid.values():
             i.toxml({})
 
 if __name__ == '__main__':

--- a/check.py
+++ b/check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 import unittest
 from guesttemplates import loader
 

--- a/create-guest-templates
+++ b/create-guest-templates
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from guesttemplates import loader
 import XenAPI

--- a/guesttemplates/blank_template.py
+++ b/guesttemplates/blank_template.py
@@ -1,3 +1,6 @@
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 import datetime
 import re
 import uuid
@@ -107,7 +110,7 @@ class Disk(object):
     def get_disk_entry(self):
         doc = minidom.Document()
         entry = doc.createElement('disk')
-        for element_name, element_value in self.__dict__.items():
+        for element_name, element_value in list(self.__dict__.items()):
             entry.setAttribute(element_name, str(element_value))
 
         return entry
@@ -271,7 +274,7 @@ class BlankTemplate(object):
         struct = doc.createElement('struct')
         ver_member.appendChild(struct)
 
-        for n, v in version.items():
+        for n, v in list(version.items()):
             value = self.create_member(doc, struct, n)
             value.appendChild(doc.createTextNode(v))
 
@@ -293,7 +296,7 @@ class BlankTemplate(object):
         struct2 = doc.createElement('struct')
         snapshot.appendChild(struct2)
 
-        for n2, v2 in record_dict.items():
+        for n2, v2 in list(record_dict.items()):
             value = self.create_member(doc, struct2, n2)
 
             if isinstance(v2, basestring) and v2 != "":
@@ -326,7 +329,7 @@ class BlankTemplate(object):
             elif isinstance(v2, dict):
                 struct3 = doc.createElement('struct')
                 value.appendChild(struct3)
-                for n3, v3 in v2.items():
+                for n3, v3 in list(v2.items()):
                     if v3:
                         value = self.create_member(doc, struct3, n3)
                         value.appendChild(doc.createTextNode(v3))
@@ -360,7 +363,7 @@ class BaseTemplate(BlankTemplate):
         blacklist = ('platform', 'other_config', 'recommendations', 'disks', 'has_vendor_device')
 
         # apply template values over current values
-        filtered_template = {k: v for k, v in template.iteritems() if k not in blacklist}
+        filtered_template = {k: v for k, v in template.items() if k not in blacklist}
         super(BaseTemplate, self).update(filtered_template)
 
         if "min_memory" in template:

--- a/guesttemplates/blank_template.py
+++ b/guesttemplates/blank_template.py
@@ -110,7 +110,7 @@ class Disk(object):
     def get_disk_entry(self):
         doc = minidom.Document()
         entry = doc.createElement('disk')
-        for element_name, element_value in list(self.__dict__.items()):
+        for element_name, element_value in self.__dict__.items():
             entry.setAttribute(element_name, str(element_value))
 
         return entry
@@ -274,7 +274,7 @@ class BlankTemplate(object):
         struct = doc.createElement('struct')
         ver_member.appendChild(struct)
 
-        for n, v in list(version.items()):
+        for n, v in version.items():
             value = self.create_member(doc, struct, n)
             value.appendChild(doc.createTextNode(v))
 
@@ -296,7 +296,7 @@ class BlankTemplate(object):
         struct2 = doc.createElement('struct')
         snapshot.appendChild(struct2)
 
-        for n2, v2 in list(record_dict.items()):
+        for n2, v2 in record_dict.items():
             value = self.create_member(doc, struct2, n2)
 
             if isinstance(v2, basestring) and v2 != "":
@@ -329,7 +329,7 @@ class BlankTemplate(object):
             elif isinstance(v2, dict):
                 struct3 = doc.createElement('struct')
                 value.appendChild(struct3)
-                for n3, v3 in list(v2.items()):
+                for n3, v3 in v2.items():
                     if v3:
                         value = self.create_member(doc, struct3, n3)
                         value.appendChild(doc.createTextNode(v3))

--- a/guesttemplates/blank_template.py
+++ b/guesttemplates/blank_template.py
@@ -1,6 +1,3 @@
-from builtins import str
-from past.builtins import basestring
-from builtins import object
 import datetime
 import re
 import uuid
@@ -23,7 +20,7 @@ def amount_to_int(amt):
 
 def get_bool_key(d, key, default):
     v = d.get(key, default)
-    if isinstance(v, basestring):
+    if isinstance(v, str):
         v = v.lower() in ('t', 'true', 'y', 'yes', '1')
     return v
 
@@ -299,7 +296,7 @@ class BlankTemplate(object):
         for n2, v2 in record_dict.items():
             value = self.create_member(doc, struct2, n2)
 
-            if isinstance(v2, basestring) and v2 != "":
+            if isinstance(v2, str) and v2 != "":
                 value.appendChild(doc.createTextNode(v2))
 
             elif isinstance(v2, datetime.datetime):

--- a/guesttemplates/blank_template.py
+++ b/guesttemplates/blank_template.py
@@ -97,7 +97,7 @@ class DiskDevices(object):
             root.appendChild(entry)
             position += 1
 
-        return doc.documentElement.toxml('utf-8')
+        return doc.documentElement.toxml()
 
 class Disk(object):
 
@@ -177,7 +177,7 @@ class Recommendations(object):
             entry.setAttribute('max', self.__dict__.get(prop.replace('-', '_'), ""))
             root.appendChild(entry)
 
-        return doc.documentElement.toxml('utf-8')
+        return doc.documentElement.toxml()
 
     def update(self, new):
         self.__dict__.update(new.__dict__)

--- a/guesttemplates/loader.py
+++ b/guesttemplates/loader.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-from builtins import bytes, object
 from guesttemplates import blank_template
 import http.client
 import socket

--- a/guesttemplates/loader.py
+++ b/guesttemplates/loader.py
@@ -10,7 +10,7 @@ import os
 import tarfile
 import io
 import time
-import urllib.request, urllib.parse, urllib.error
+import urllib.parse
 import os.path
 
 # List of places to look for config files. The paths are ordered by

--- a/guesttemplates/loader.py
+++ b/guesttemplates/loader.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
-from builtins import object
+from builtins import bytes, object
 from guesttemplates import blank_template
 import http.client
 import socket
@@ -123,12 +123,12 @@ class Loader(object):
         """Return a tar-formatted string containing 'data' in a file
         called 'name'."""
 
-        datafh = io.StringIO(data)
+        datafh = io.BytesIO(bytes(data, encoding='utf-8'))
         tarinfo = tarfile.TarInfo(name)
         tarinfo.size = len(data)
         tarinfo.mtime = time.time()
 
-        tarfh = io.StringIO()
+        tarfh = io.BytesIO()
         tar = tarfile.TarFile(fileobj=tarfh, mode='w')
         tar.addfile(tarinfo, fileobj=datafh)
         tar.close()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from setuptools import setup
 


### PR DESCRIPTION
I applied futurize, then a manual fix. `check.py` runs successfully (and I made it output the XML files locally so that I could compare them). I also tested with a template containing non-ASCII utf-8 characters. I could not test `create-guest-templates` yet due to an error why using XenAPI from PyPi.

The last two commits fully transition to python3, without python2 support.