### PR TITLE
CP-41964:Templates modification for guest support becomes EOL, Deprecated or Official in XenServer

### DIFF
--- a/json/coreos.json
+++ b/json/coreos.json
@@ -1,9 +1,0 @@
-{
-    "uuid": "094706dd-5d22-4830-99b7-c710769c9dcc",
-    "reference_label": "coreos",
-    "name_label": "CoreOS",
-    "derived_from": "base-hvmlinux.json",
-    "min_memory": "2G",
-    "max_memory": "512G",
-    "disks": [ { "size": "8G" } ]
-}

--- a/json/debian-11.json
+++ b/json/debian-11.json
@@ -1,7 +1,7 @@
 {
     "uuid": "acfeecf4-4007-412b-8f13-6d61a6aee5bd",
     "reference_label": "debian-11",
-    "name_label": "Debian Bullseye 11 (experimental)",
+    "name_label": "Debian Bullseye 11",
     "derived_from": "base-hvmlinux.json",
     "min_memory": "512M",
     "disks": [ { "size": "10G" } ]

--- a/json/sles-12-sp4-64bit.json
+++ b/json/sles-12-sp4-64bit.json
@@ -1,6 +1,6 @@
 {
   "uuid": "c060fa00-8c96-4eb8-bcc9-772daaa01885",
   "reference_label": "sles-12-sp4-64bit",
-  "name_label": "SUSE Linux Enterprise Server 12 SP4 (64-bit)",
+  "name_label": "SUSE Linux Enterprise Server 12 SP4 (64-bit) (deprecated)",
   "derived_from": "base-sle-hvm-64bit.json"
 }

--- a/json/ubuntu-18.04.json
+++ b/json/ubuntu-18.04.json
@@ -1,7 +1,7 @@
 {
     "uuid": "74ae424d-a1d3-4d96-9827-d1d60a4c7511",
     "reference_label": "ubuntu-18.04",
-    "name_label": "Ubuntu Bionic Beaver 18.04",
+    "name_label": "Ubuntu Bionic Beaver 18.04 (deprecated)",
     "derived_from": "base-hvmlinux.json",
     "min_memory": "512M",
     "disks": [ { "size": "10G" } ]


### PR DESCRIPTION
Test Execution
https://info.citrite.net/pages/viewpage.action?pageId=1625982439