### PR TITLE
CP-44127 Support New Guest Templates include CentOS Stream 9, Rocky 9 and Debian 12

### DIFF
--- a/json/centos-9.json
+++ b/json/centos-9.json
@@ -1,0 +1,6 @@
+{
+    "uuid": "a3d70e4d-c5ac-4dfb-999b-30a0a7efe546",
+    "reference_label": "centos-9",
+    "name_label": "CentOS Stream 9 (preview)",
+    "derived_from": "base-el-7.json"
+}

--- a/json/debian-12.json
+++ b/json/debian-12.json
@@ -1,0 +1,8 @@
+{
+    "uuid": "07d91aaa-43f7-430a-bf84-0edb6714df0f",
+    "reference_label": "debian-12",
+    "name_label": "Debian Bookworm 12 (preview)",
+    "derived_from": "base-hvmlinux.json",
+    "min_memory": "1G",
+    "disks": [ { "size": "10G" } ]
+}

--- a/json/rocky-9.json
+++ b/json/rocky-9.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "1a647cf9-99c1-4e9c-b3b4-6b9989c530be",
+    "reference_label": "rocky-9",
+    "name_label": "Rocky Linux 9 (preview)",
+    "derived_from": "base-el-7.json",
+    "disks": [ { "size": "15G" } ]
+}


### PR DESCRIPTION
CP-44127 Add New Guest Templates include CentOS Stream 9, Rocky 9 and Debian 12