### PR TITLE
CP-44378 Remove 'preview' from Ubuntu 22.04

### DIFF
--- a/json/ubuntu-22.04.json
+++ b/json/ubuntu-22.04.json
@@ -1,7 +1,7 @@
 {
     "uuid": "df1a0e64-3799-482b-aa9f-1ed713c7dac5",
     "reference_label": "ubuntu-22.04",
-    "name_label": "Ubuntu Jammy Jellyfish 22.04 (preview)",
+    "name_label": "Ubuntu Jammy Jellyfish 22.04",
     "derived_from": "base-hvmlinux.json",
     "min_memory": "1G",
     "disks": [ { "size": "10G" } ]


### PR DESCRIPTION
Remove 'preview' from Ubuntu 22.04 guest template.