### PR TITLE
CP-39782 Modify Guest Template to Support UEFI Boot

### DIFF
--- a/json/base-linux-uefi.json
+++ b/json/base-linux-uefi.json
@@ -1,0 +1,12 @@
+{
+    "platform": {
+        "device-model": "qemu-upstream-uefi",
+        "secureboot": "true"
+    },
+    "HVM_boot_params": {
+        "firmware": "uefi"
+    },
+    "supports_uefi": "yes",
+    "supports_secure_boot": "yes",
+    "derived_from": "base-hvmlinux.json"
+}

--- a/json/debian-12.json
+++ b/json/debian-12.json
@@ -2,7 +2,7 @@
     "uuid": "07d91aaa-43f7-430a-bf84-0edb6714df0f",
     "reference_label": "debian-12",
     "name_label": "Debian Bookworm 12 (preview)",
-    "derived_from": "base-hvmlinux.json",
+    "derived_from": "base-linux-uefi.json",
     "min_memory": "1G",
     "disks": [ { "size": "10G" } ]
 }

--- a/json/rhel-8.json
+++ b/json/rhel-8.json
@@ -2,5 +2,7 @@
     "uuid": "612863ed-900d-456d-b4b7-38b70915fd1f",
     "reference_label": "rhel-8",
     "name_label": "Red Hat Enterprise Linux 8",
-    "derived_from": "base-el-7.json"
+    "derived_from": "base-linux-uefi.json",
+    "min_memory": "2G",
+    "disks": [ { "size": "10G" } ]
 }

--- a/json/rhel-9.json
+++ b/json/rhel-9.json
@@ -2,5 +2,7 @@
     "uuid": "6c91b878-5095-421e-a914-224b3bb1088c",
     "reference_label": "rhel-9",
     "name_label": "Red Hat Enterprise Linux 9 (preview)",
-    "derived_from": "base-el-7.json"
+    "derived_from": "base-linux-uefi.json",
+    "min_memory": "2G",
+    "disks": [ { "size": "10G" } ]
 }

--- a/json/ubuntu-20.04.json
+++ b/json/ubuntu-20.04.json
@@ -2,7 +2,7 @@
     "uuid": "2cf37285-57bc-4633-a24f-0c6c825dda66",
     "reference_label": "ubuntu-20.04",
     "name_label": "Ubuntu Focal Fossa 20.04",
-    "derived_from": "base-hvmlinux.json",
+    "derived_from": "base-linux-uefi.json",
     "min_memory": "512M",
     "disks": [ { "size": "10G" } ]
 }

--- a/json/ubuntu-22.04.json
+++ b/json/ubuntu-22.04.json
@@ -2,7 +2,7 @@
     "uuid": "df1a0e64-3799-482b-aa9f-1ed713c7dac5",
     "reference_label": "ubuntu-22.04",
     "name_label": "Ubuntu Jammy Jellyfish 22.04 (preview)",
-    "derived_from": "base-hvmlinux.json",
+    "derived_from": "base-linux-uefi.json",
     "min_memory": "1G",
     "disks": [ { "size": "10G" } ]
 }


### PR DESCRIPTION
Adding the following guest to support UEFI and secure boot:

- Debian 12
- Ubuntu 20.04
- Ubuntu 22.04
- RHEL 8
- RHEL 9