### PR TITLE
CP-46122: Keep tar format to GNU_FORMAT explicitly for xs9

### DIFF
--- a/guesttemplates/loader.py
+++ b/guesttemplates/loader.py
@@ -125,7 +125,7 @@ class Loader(object):
         tarinfo.mtime = time.time()
 
         tarfh = io.BytesIO()
-        tar = tarfile.TarFile(fileobj=tarfh, mode='w')
+        tar = tarfile.TarFile(fileobj=tarfh, mode='w', format=tarfile.GNU_FORMAT)
         tar.addfile(tarinfo, fileobj=datafh)
         tar.close()
         datafh.close()


### PR DESCRIPTION
During import guest template, create-guest-templates put xapi /import_metadata and upload tar compressed xml.

The default tar format updated to PAX_FORMAT since python 3.8 https://docs.python.org/3/library/tarfile.html#tarfile.DEFAULT_FORMAT

* in PAX_FORMAT, the tar header is b'././@PaxHeader'
* in GNU_FORMAT, the tar header is the name, which is b'ova.xml'

Xapi http server check the uploaded tar file for the header, and reject the file if the header does not match the GNU_FORMAT one.

import expects the next file in the stream to be [6f 76 61 2e 78 6d 6c ]; got [2e 2f 2e 2f 40 50 61 78 48 65 61 64 65 72 ]

Fix the issue by keeping GNU_FORMAT format for xs9 explictly This fix works for both xs8 and xs9