### PR TITLE
CP-46356 remove the word preview from template name

### DIFF
--- a/json/windows-11.json
+++ b/json/windows-11.json
@@ -1,7 +1,7 @@
 {
     "uuid": "1f8728f9-6354-4a68-adc3-222c34f2bb94",
     "reference_label": "windows-11",
-    "name_label": "Windows 11 (preview)",
+    "name_label": "Windows 11"
     "name_description": "Clones of this template will automatically provision their storage when first booted and then reconfigure themselves with the optimal settings for Windows 11.",
     "derived_from": "base-windows-uefi.json",
     "min_memory": "4G",


### PR DESCRIPTION
Removing the "(preview)" from the win11 template.
