### PR TITLE
CP-47662 Remove deprecated guest templates SUSE Linux 12 SP4 and Ubuntu 18.04

### DIFF
--- a/json/sles-12-sp4-64bit.json
+++ b/json/sles-12-sp4-64bit.json
@@ -1,6 +1,0 @@
-{
-  "uuid": "c060fa00-8c96-4eb8-bcc9-772daaa01885",
-  "reference_label": "sles-12-sp4-64bit",
-  "name_label": "SUSE Linux Enterprise Server 12 SP4 (64-bit) (deprecated)",
-  "derived_from": "base-sle-hvm-64bit.json"
-}

--- a/json/ubuntu-18.04.json
+++ b/json/ubuntu-18.04.json
@@ -1,8 +1,0 @@
-{
-    "uuid": "74ae424d-a1d3-4d96-9827-d1d60a4c7511",
-    "reference_label": "ubuntu-18.04",
-    "name_label": "Ubuntu Bionic Beaver 18.04 (deprecated)",
-    "derived_from": "base-hvmlinux.json",
-    "min_memory": "512M",
-    "disks": [ { "size": "10G" } ]
-}


### PR DESCRIPTION
As title remove deprecated guest templates SUSE Linux 12 SP4 and Ubuntu 18.04