### PR TITLE
CA-388398: cores-per-socket causes a massive performance hit, remove it

### DIFF
--- a/json/base-windows.json
+++ b/json/base-windows.json
@@ -9,7 +9,6 @@
         "install-methods": "cdrom"
     },
     "platform": {
-        "cores-per-socket": "2",
         "device_id": "0002",
         "viridian": "true",
         "viridian_time_ref_count": "true",


### PR DESCRIPTION
This got introduced in 6822644, to ensure that VMs have a single socket by default. However that'd be the default *without* a cores-per-socket setting anyway (1 socket, all vcpus as cores).

In CA-388398 we've measured an ~60% performance difference in an Apache Siege benchmark with all cores-per-socket settings, except:
* cores-per-socket==vcpu count
* cores-per-socket absent

Although that measurement was done on Linux, the setting is expected to have a detrimental effect elsewhere, the topology changes that Xen has to make in order to implement cores-per-socket results in a topology that is not quite correct.

Although cores-per-socket==vcpu with the setting here, as soon as the user adds more vCPUs that won't be true anymore.

Fixes: 6822644 ("Update base Windows templates to 2 vCPUs")