### PR TITLE
CA-390776 Oracle 8 should have 2 vCPUs at least

### DIFF
--- a/json/oel-8.json
+++ b/json/oel-8.json
@@ -4,5 +4,7 @@
     "name_label": "Oracle Linux 8",
     "derived_from": "base-linux-uefi.json",
     "min_memory": "2G",
+    "VCPUs_at_startup": 2,
+    "VCPUs_max": 2,
     "disks": [ { "size": "10G" } ]
 }


### PR DESCRIPTION
We've encountered an issue with some advanced feature like DMC when supporting Oracle 8 UEFI and Secure boot, due to its requirement of two logical vCPUs, as outlined in the Oracle 8 System requirements (refer to: https://docs.oracle.com/en/operating-systems/oracle-linux/8/install/install-PreparingToInstall.html#prep-install). Unfortunately, our template does not currently enforce this requirement.

Based on our implementation in XenCenter, the initial number of vCPUs displayed in the XC tab depends on either the VCPUs_at_startup or VCPUs_max parameters. If the guest's metadata RestrictVcpuHotplug is set to true, it will extract from VCPUs_at_startup; otherwise, it will extract from VCPUs_max. To ensure compatibility and avoid potential issues, I will add both parameters simultaneously