### PR TITLE
CP-48730 Yangtze Update: Oracle 7/8 Requires Minimum 2 vCPUs

### DIFF
--- a/json/oel-7.json
+++ b/json/oel-7.json
@@ -2,5 +2,7 @@
     "uuid": "f873abe0-b138-4995-8f6f-498b423d234d",
     "reference_label": "oel-7",
     "name_label": "Oracle Linux 7",
-    "derived_from": "base-el-7.json"
+    "derived_from": "base-el-7.json",
+    "VCPUs_at_startup": 2,
+    "VCPUs_max": 2
 }

--- a/json/oel-8.json
+++ b/json/oel-8.json
@@ -2,5 +2,7 @@
     "uuid": "6959dfe8-534c-4c58-8a8c-3c3792293543",
     "reference_label": "oel-8",
     "name_label": "Oracle Linux 8",
-    "derived_from": "base-el-7.json"
+    "derived_from": "base-el-7.json",
+    "VCPUs_at_startup": 2,
+    "VCPUs_max": 2
 }


### PR DESCRIPTION
After verifying the Oracle 7 and Oracle 8 minimal system requirement, both Distros require at least two vCPUs, Therefore, the templates should be updated.

refer to: https://docs.oracle.com/en/operating-systems/oracle-linux/8/install/install-PreparingToInstall.html#prep-install
https://docs.oracle.com/en/operating-systems/oracle-linux/7/relnotes7.6/relnotes-SystemRequirementsandLimits.html#ol7-system-requirements

`Minimum of 2 logical CPUs up to 2048 logical CPUs`

