### PR TITLE
Add support for Ubuntu 24.04 on Yangtze

### DIFF
--- a/json/oel-8.json
+++ b/json/oel-8.json
@@ -2,5 +2,7 @@
     "uuid": "6959dfe8-534c-4c58-8a8c-3c3792293543",
     "reference_label": "oel-8",
     "name_label": "Oracle Linux 8",
+    "VCPUs_at_startup": 2,
+    "VCPUs_max": 2,
     "derived_from": "base-el-7.json"
 }

--- a/json/ubuntu-24.04.json
+++ b/json/ubuntu-24.04.json
@@ -1,0 +1,8 @@
+{
+    "uuid": "ff1f3e17-84d9-4d72-962d-571c4ceb527b",
+    "reference_label": "ubuntu-24.04",
+    "name_label": "Ubuntu Noble Numbat 24.04",
+    "derived_from": "base-hvmlinux.json",
+    "min_memory": "1G",
+    "disks": [ { "size": "10G" } ]
+}


### PR DESCRIPTION
Backport the following modification from XS8 to Yangtze
- CP-44647 Add Ubuntu 24.04 templates
- CA-390776 Oracle 8 should have 2 vCPUs at least