### PR TITLE
Add support for Ubuntu 24.04 on XS 8

### DIFF
--- a/json/centos-9.json
+++ b/json/centos-9.json
@@ -1,6 +1,6 @@
 {
     "uuid": "a3d70e4d-c5ac-4dfb-999b-30a0a7efe546",
     "reference_label": "centos-9",
-    "name_label": "CentOS Stream 9 (preview)",
+    "name_label": "CentOS Stream 9",
     "derived_from": "base-el-7.json"
 }

--- a/json/debian-12.json
+++ b/json/debian-12.json
@@ -1,7 +1,7 @@
 {
     "uuid": "07d91aaa-43f7-430a-bf84-0edb6714df0f",
     "reference_label": "debian-12",
-    "name_label": "Debian Bookworm 12 (preview)",
+    "name_label": "Debian Bookworm 12",
     "derived_from": "base-linux-uefi.json",
     "min_memory": "1G",
     "disks": [ { "size": "10G" } ]

--- a/json/rhel-9.json
+++ b/json/rhel-9.json
@@ -1,7 +1,7 @@
 {
     "uuid": "6c91b878-5095-421e-a914-224b3bb1088c",
     "reference_label": "rhel-9",
-    "name_label": "Red Hat Enterprise Linux 9 (preview)",
+    "name_label": "Red Hat Enterprise Linux 9",
     "derived_from": "base-linux-uefi.json",
     "min_memory": "2G",
     "disks": [ { "size": "10G" } ]

--- a/json/rocky-9.json
+++ b/json/rocky-9.json
@@ -1,7 +1,7 @@
 {
     "uuid": "1a647cf9-99c1-4e9c-b3b4-6b9989c530be",
     "reference_label": "rocky-9",
-    "name_label": "Rocky Linux 9 (preview)",
+    "name_label": "Rocky Linux 9",
     "derived_from": "base-linux-uefi.json",
     "min_memory": "2G",
     "disks": [ { "size": "15G" } ]

--- a/json/ubuntu-24.04.json
+++ b/json/ubuntu-24.04.json
@@ -1,0 +1,8 @@
+{
+    "uuid": "ff1f3e17-84d9-4d72-962d-571c4ceb527b",
+    "reference_label": "ubuntu-24.04",
+    "name_label": "Ubuntu Noble Numbat 24.04 (preview)",
+    "derived_from": "base-linux-uefi.json",
+    "min_memory": "1G",
+    "disks": [ { "size": "10G" } ]
+}


### PR DESCRIPTION
- CP-47949 Support New Guest Template Ubuntu 24.04
- CP-47949 Remove 'preview' label from RHEL9, Rocky9, CentOS Stream 9 and Debian 12