### PR TITLE
CP-309456 Remove EOL templates from XS9

### DIFF
--- a/json/centos-7.json
+++ b/json/centos-7.json
@@ -1,6 +1,0 @@
-{
-    "uuid": "11fd3dc9-96cc-49af-b091-a2ca7e94c589",
-    "reference_label": "centos-7",
-    "name_label": "CentOS 7",
-    "derived_from": "base-el-7.json"
-}

--- a/json/debian-10.json
+++ b/json/debian-10.json
@@ -1,8 +1,0 @@
-{
-    "uuid": "bac315b4-66fd-4488-82f5-9808e927b4b9",
-    "reference_label": "debian-10",
-    "name_label": "Debian Buster 10",
-    "derived_from": "base-hvmlinux.json",
-    "min_memory": "512M",
-    "disks": [ { "size": "10G" } ]
-}

--- a/json/oel-7.json
+++ b/json/oel-7.json
@@ -1,6 +1,0 @@
-{
-    "uuid": "f873abe0-b138-4995-8f6f-498b423d234d",
-    "reference_label": "oel-7",
-    "name_label": "Oracle Linux 7",
-    "derived_from": "base-el-7.json"
-}

--- a/json/rhel-7.json
+++ b/json/rhel-7.json
@@ -1,6 +1,0 @@
-{
-    "uuid": "03d30863-86a2-428e-94c8-88ddfcb8cd29",
-    "reference_label": "rhel-7",
-    "name_label": "Red Hat Enterprise Linux 7",
-    "derived_from": "base-el-7.json"
-}

--- a/json/sl-7.json
+++ b/json/sl-7.json
@@ -1,6 +1,0 @@
-{
-    "uuid": "4b116889-af64-42af-ba86-75dcb3cb7828",
-    "reference_label": "sl-7",
-    "name_label": "Scientific Linux 7",
-    "derived_from": "base-el-7.json"
-}

--- a/json/ubuntu-20.04.json
+++ b/json/ubuntu-20.04.json
@@ -1,8 +1,0 @@
-{
-    "uuid": "2cf37285-57bc-4633-a24f-0c6c825dda66",
-    "reference_label": "ubuntu-20.04",
-    "name_label": "Ubuntu Focal Fossa 20.04",
-    "derived_from": "base-linux-uefi.json",
-    "min_memory": "512M",
-    "disks": [ { "size": "10G" } ]
-}


### PR DESCRIPTION
The following distribution templates have reached EOL and are being removed from the template set:

- CentOS 7
- RHEL 7
- Debian 10
- Oracle Linux 7
- Ubuntu 20.04
- Scientific Linux 7