### PR TITLE
CA-423707: Retry on fail by systemd

### DIFF
--- a/service/create-guest-templates.service
+++ b/service/create-guest-templates.service
@@ -8,6 +8,12 @@ ConditionPathExists=!/var/lib/misc/ran-create-guest-templates
 Type=oneshot
 ExecStart=/usr/bin/create-guest-templates-wrapper
 RemainAfterExit=yes
+Restart=on-failure
+RestartSec=60s
+
+# Avoid tight restart loops if XAPI/import is persistently failing.
+StartLimitIntervalSec=20min
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
During create-guest-templates start, it will
- Find template JSON files
- Load templates from disk
- Remove old default templates
- Insert new templates
- Create service condition file

However, it may fail during one of insert new templates, Insert does HTTP put request, and xapi may not able to handle it in time properly, especially during host boot and toolstack initialization.

The service restart sequence is re-enterable, as it clean up and upload on each start. So a service retry is added to ask systemd to retry the upload on failure.