### PR TITLE
CP-311170 Remove NeoKylin v7 from guest templates set

### DIFF
--- a/json/base-kylin-7.json
+++ b/json/base-kylin-7.json
@@ -1,5 +1,0 @@
-{
-    "derived_from": "base-hvmlinux.json",
-    "min_memory": "1G",
-    "disks": [ { "size": "10G" } ]
-}

--- a/json/kylin-7.json
+++ b/json/kylin-7.json
@@ -1,6 +1,0 @@
-{
-    "uuid": "7279a78a-4756-4fc3-99f0-3e7694c0319e",
-    "reference_label": "kylin-server-7",
-    "name_label": "NeoKylin Linux Server 7",
-    "derived_from": "base-kylin-7.json"
-}


### PR DESCRIPTION
Although no official EOL declaration for NeoKylin v7, assume it is a RHEL7-like distro, it should have reached EOL, remove it from guest templates set.